### PR TITLE
fix: message alias overwrite

### DIFF
--- a/internals/proxy/middlewares/aliases.go
+++ b/internals/proxy/middlewares/aliases.go
@@ -107,7 +107,7 @@ func getData(key string, aliases []middlewareTypes.DataAlias, data map[string]an
 				value = aliasValue
 			}
 
-			data[alias.Alias] = nil
+			delete(data, alias.Alias)
 		}
 	}
 

--- a/internals/proxy/middlewares/message.go
+++ b/internals/proxy/middlewares/message.go
@@ -84,13 +84,17 @@ func (data MessageMiddleware) Use() http.Handler {
 func TemplateMessage(template string, data map[string]any, VARIABLES map[string]any) (map[string]any, error) {
 	log.Dev(template)
 
-	data["message"] = template
+	data["message_template"] = template
 
 	data, ok, err := TemplateBody(data, VARIABLES)
 
 	if err != nil || !ok || data == nil {
 		return data, err
 	}
+
+	data["message"] = data["message_template"]
+
+	delete(data, "message_template")
 
 	return data, nil
 }

--- a/internals/proxy/middlewares/message.go
+++ b/internals/proxy/middlewares/message.go
@@ -82,6 +82,8 @@ func (data MessageMiddleware) Use() http.Handler {
 }
 
 func TemplateMessage(template string, data map[string]any, VARIABLES map[string]any) (map[string]any, error) {
+	log.Dev(template)
+
 	data["message"] = template
 
 	data, ok, err := TemplateBody(data, VARIABLES)

--- a/internals/proxy/middlewares/template.go
+++ b/internals/proxy/middlewares/template.go
@@ -121,7 +121,7 @@ func TemplateBody(data map[string]any, VARIABLES map[string]any) (map[string]any
 
 		normalizedData, err := jsonutils.GetJsonSafe[map[string]any](jsonStr)
 		
-		log.Dev(err.Error())
+		log.Dev("Error removing @ and encoding: ", err.Error())
 
 		if err == nil {
 			data = normalizedData

--- a/internals/proxy/middlewares/template.go
+++ b/internals/proxy/middlewares/template.go
@@ -120,11 +120,11 @@ func TemplateBody(data map[string]any, VARIABLES map[string]any) (map[string]any
 		jsonStr = re.ReplaceAllString(jsonStr, "{{.$1}}")
 
 		normalizedData, err := jsonutils.GetJsonSafe[map[string]any](jsonStr)
-		
-		log.Dev("Error removing @ and encoding: ", err.Error())
 
 		if err == nil {
 			data = normalizedData
+		} else {
+			log.Dev(err.Error())
 		}
 	}
 

--- a/internals/proxy/middlewares/template.go
+++ b/internals/proxy/middlewares/template.go
@@ -123,10 +123,10 @@ func TemplateBody(data map[string]any, VARIABLES map[string]any) (map[string]any
 
 		if err == nil {
 			data = normalizedData
-		} else {
-			log.Dev(err.Error())
 		}
 	}
+
+	log.Dev(jsonStr)
 
 	templatedData, err := templating.RenderJSON("body", data, VARIABLES)
 

--- a/internals/proxy/middlewares/template.go
+++ b/internals/proxy/middlewares/template.go
@@ -120,6 +120,8 @@ func TemplateBody(data map[string]any, VARIABLES map[string]any) (map[string]any
 		jsonStr = re.ReplaceAllString(jsonStr, "{{.$1}}")
 
 		normalizedData, err := jsonutils.GetJsonSafe[map[string]any](jsonStr)
+		
+		log.Dev(err.Error())
 
 		if err == nil {
 			data = normalizedData

--- a/internals/proxy/middlewares/template.go
+++ b/internals/proxy/middlewares/template.go
@@ -126,8 +126,6 @@ func TemplateBody(data map[string]any, VARIABLES map[string]any) (map[string]any
 		}
 	}
 
-	log.Dev(jsonStr)
-
 	templatedData, err := templating.RenderJSON("body", data, VARIABLES)
 
 	if err != nil {

--- a/utils/templating/templating.go
+++ b/utils/templating/templating.go
@@ -7,6 +7,9 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/codeshelldev/secured-signal-api/utils/jsonutils"
+	"github.com/codeshelldev/secured-signal-api/utils/logger"
 )
 
 func normalize(value any) string {
@@ -128,6 +131,8 @@ func RenderJSONTemplate(name string, data map[string]any, variables map[string]a
 
 	tmplStr := string(jsonBytes)
 
+	logger.Dev("1\n", tmplStr)
+
 	re, err := regexp.Compile(`{{\s*\.([a-zA-Z0-9_.]+)\s*}}`)
 
 	// Add normalize() to be able to remove Quotes from Arrays
@@ -135,17 +140,23 @@ func RenderJSONTemplate(name string, data map[string]any, variables map[string]a
     	tmplStr = re.ReplaceAllString(tmplStr, "{{normalize .$1}}")
 	}
 
+	logger.Dev("2\n", tmplStr)
+
 	templt := CreateTemplateWithFunc(name, template.FuncMap{
         "normalize": normalizeJSON,
     })
 
 	jsonStr, err := ParseTemplate(templt, tmplStr, variables)
 
+	logger.Dev("3\n", tmplStr)
+
 	if err != nil {
 		return nil, err
 	}
 
 	jsonStr = cleanQuotedPairsJSON(jsonStr)
+
+	logger.Dev("4\n", tmplStr)
 
 	// Remove the Quotes around "<<[item1,item2]>>"
 	re, err = regexp.Compile(`"<<(.*?)>>"`)
@@ -156,7 +167,11 @@ func RenderJSONTemplate(name string, data map[string]any, variables map[string]a
 
 	jsonStr = re.ReplaceAllString(jsonStr, "$1")
 
+	logger.Dev("5\n", tmplStr)
+
 	err = json.Unmarshal([]byte(jsonStr), &data)
+
+	logger.Dev("6\n", jsonutils.ToJson(data))
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Summary
This PR solves #57, where `message` is being used inside of the Message Template, due to previous mistake `message` is set to the Template, which is causing `message` to reference itself, causing an error.

### Changes
* solved `message` Template loop

### Checklist
- [X] PR tested
- [X] Docs updated (if applicable)
