### PR TITLE
fix: mapping middleware in chain

### DIFF
--- a/internals/proxy/proxy.go
+++ b/internals/proxy/proxy.go
@@ -36,7 +36,7 @@ func (proxy Proxy) Init() http.Handler {
 		Use(m.Auth).
 		Use(m.Endpoints).
 		Use(m.Template).
-		Use(m.Aliases).
+		Use(m.Mapping).
 		Use(m.Message).
 		Then(proxy.Use())
 


### PR DESCRIPTION
### Summary
Added missing rename in proxy.go

### Changes
* rename m.Aliases to m.Mapping

### Checklist
- [x] PR tested
- [ ] Docs updated (if applicable)
