### PR TITLE
docs/fix: orgname

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -29,7 +29,7 @@ const config = {
 
 	// GitHub pages deployment config.
 	// If you aren't using GitHub pages, you don't need these.^
-	organizationName: "CodeShell", // Usually your GitHub org/user name.
+	organizationName: "codeshelldev", // Usually your GitHub org/user name.
 	projectName: "secured-signal-api", // Usually your repo name.
 
 	onBrokenLinks: "throw",


### PR DESCRIPTION
### Summary
<!--
Describe what this PR does.
-->
Fix the orgname in docusaurus config.

### Changes
<!--
List of all changes below.
-->
* changed CodeShell to codeshelldev in orgname

### Checklist
- [ ] PR tested
- [ ] Docs updated (if applicable)

### Related
- Docs PR: 
- Code PR: 
- Issues: 
