### PR TITLE
docs: placeholders cannot be used for `number` in hass

### DIFF
--- a/docs/integrations/home-assistant/configuration.yml
+++ b/docs/integrations/home-assistant/configuration.yml
@@ -2,6 +2,6 @@ notify:
   - name: signal
     platform: signal_messenger
     url: "http://sec-signal-api:8880/auth=API_TOKEN"
-    number: "+123400001" # tip: use a placeholder instead
+    number: "+123400001"
     recipients:
-      - "+123400002"
+      - "+123400002" # tip: use a placeholder instead

--- a/docs/integrations/home-assistant/home-assistant.md
+++ b/docs/integrations/home-assistant/home-assistant.md
@@ -16,13 +16,16 @@ To be able to use the Signal Messenger integration in Home Assistant you need to
 {{{ #://./configuration.yml }}}
 ```
 
+> [!IMPORTANT]
+> Home Assistant requires `number` to actually be a number, so using placeholders is not supported at the moment
+
 Here we are taking advantage of the `url` field for adding `/auth=API_TOKEN` in order to use [Path Auth](../usage#auth).
 
 For more detailed configuration instructions read the [official Home Assistant docs](https://www.home-assistant.io/integrations/signal_messenger/).
 
 ### 2. Enabling Path Auth
 
-By default [Path Auth](../usage#auth) is disabled, so we first need to enable it in the config by adding `path` to [`auth.methods`](../configuration/auth):
+By default, [Path Auth](../usage#auth) is disabled, so we first need to enable it in the config by adding `path` to [`auth.methods`](../configuration/auth):
 
 ```yaml
 api:


### PR DESCRIPTION
### Summary

<!--
Describe what this PR does.
-->

Adds a disclaimer that placeholders cannot be used in the `number` field due to Home Assistant's strict parser.

### Changes

<!--
List of all changes below.
-->

- added important alert
- moved tip to recipient item instead of `number`
